### PR TITLE
Add possibility not to render template

### DIFF
--- a/Gallery.php
+++ b/Gallery.php
@@ -28,6 +28,12 @@ class Gallery extends Widget
      */
     public $options = [];
     /**
+     * @var boolean whether to write html template of Gallery on initialization.
+     * Useful when you want multiple galleries on page without code repeating.
+     * Need to specify id of container through clientOptions though.
+     */
+    public $renderTemplate = true;
+    /**
      * @var array the HTML attributes for the lightbox container tag.
      * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
      */
@@ -88,7 +94,9 @@ class Gallery extends Widget
             return null;
         }
         echo $this->renderItems();
-        echo $this->renderTemplate();
+        if ($this->renderTemplate) {
+            echo $this->renderTemplate();
+        }
         $this->registerClientScript();
     }
 

--- a/assets/dosamigos-blueimp-gallery.js
+++ b/assets/dosamigos-blueimp-gallery.js
@@ -8,10 +8,10 @@ if (typeof dosamigos == "undefined" || !dosamigos) {
 }
 dosamigos.gallery = (function($){
     var pub = {
-        registerLightBoxHandlers: function(selector, options) {
+        registerLightBoxHandlers: function(selector, opts) {
             $(document).off('click.gallery', selector).on('click.gallery', selector, function() {
                 var links = $(this).parent().find('a.gallery-item');
-                var options = options || {};
+                var options = opts || {};
                 options.index = $(this)[0];
                 blueimp.Gallery(links, options);
                 return false;


### PR DESCRIPTION
Removed overwriting 'options' variable in javascript plugin initialization file, so that now it's possible to actually pass the params to Blue Imp Gallery Plugin. Also added property to prevent rendering template of Gallery for multiple galleries per page.
